### PR TITLE
Add default user if not found

### DIFF
--- a/hcvswitch.sh
+++ b/hcvswitch.sh
@@ -74,7 +74,7 @@ hcv_use() {
 hcv_conf() {
     local KEY="$1"
     VAL=$(grep -e "$KEY" "$HCVSWITCH_CURRENT" | cut -f "2-" -d ':' | sed -e 's! !!g; s!\"!!g')
-    echo "$VAL"
+    echo "${VAL:=$HCVSWITCH_DEFAULT_USER}"
 }
 
 hcv_auth() {


### PR DESCRIPTION
- If applied, this commit will...
Adds a default user if the auth_method is not found

- Explain why this change is being made...
This helps allow multiple people use the same configuration
but with different usernames

- Provide links to any relevant tickets, articles, or other resources...